### PR TITLE
[JBPM-9032] PMML backend for the prediction service does not work with Java 11

### DIFF
--- a/jbpm-recommendation-pmml-logistic-regression/pom.xml
+++ b/jbpm-recommendation-pmml-logistic-regression/pom.xml
@@ -59,6 +59,11 @@
           <version>${version.org.kie}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+          <version>1.0.5.Final</version>
+        </dependency>
       </dependencies>
     </dependencyManagement>
 
@@ -66,6 +71,18 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-internal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>

--- a/jbpm-recommendation-pmml-random-forest/pom.xml
+++ b/jbpm-recommendation-pmml-random-forest/pom.xml
@@ -58,6 +58,11 @@
           <version>${version.org.kie}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+          <version>1.0.5.Final</version>
+        </dependency>
       </dependencies>
   </dependencyManagement>
   
@@ -65,6 +70,18 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-internal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>


### PR DESCRIPTION
Add missing JAXB dependencies.

@jiripetrlik ptal. Thanks!