### PR TITLE
Fixed failing tests due to BAQE-1328

### DIFF
--- a/jbpm-recommendation-pmml-logistic-regression/src/test/resources/datasource.properties
+++ b/jbpm-recommendation-pmml-logistic-regression/src/test/resources/datasource.properties
@@ -1,0 +1,23 @@
+# BTM properties
+maxPoolSize=${maven.btm.maxPoolSize}
+allowLocalTransactions=true
+# JDBC/Database properties that are set in the maven pom
+#
+#   the below variable names (i.e. "${maven.datasource.classname}) are
+# automagically replaced with their values (defined in the pom.xml)
+# because of the fact that <filtering> is set to true in for the
+# src/test/resources directory in the pom.
+#
+className=${maven.datasource.classname}
+driverClassName=${maven.jdbc.driver.class}
+user=${maven.jdbc.username}
+password=${maven.jdbc.password}
+url=${maven.jdbc.url}
+serverName=${maven.jdbc.db.server}
+portNumber=${maven.jdbc.db.port}
+databaseName=${maven.jdbc.db.name}
+dialect=${maven.hibernate.dialect}
+defaultSchema=${maven.jdbc.schema}
+dbBaseDir=${basedir}
+makeBaseDb=false
+testMarshalling=false

--- a/jbpm-recommendation-pmml-random-forest/src/test/resources/datasource.properties
+++ b/jbpm-recommendation-pmml-random-forest/src/test/resources/datasource.properties
@@ -1,0 +1,23 @@
+# BTM properties
+maxPoolSize=${maven.btm.maxPoolSize}
+allowLocalTransactions=true
+# JDBC/Database properties that are set in the maven pom
+#
+#   the below variable names (i.e. "${maven.datasource.classname}) are
+# automagically replaced with their values (defined in the pom.xml)
+# because of the fact that <filtering> is set to true in for the
+# src/test/resources directory in the pom.
+#
+className=${maven.datasource.classname}
+driverClassName=${maven.jdbc.driver.class}
+user=${maven.jdbc.username}
+password=${maven.jdbc.password}
+url=${maven.jdbc.url}
+serverName=${maven.jdbc.db.server}
+portNumber=${maven.jdbc.db.port}
+databaseName=${maven.jdbc.db.name}
+dialect=${maven.hibernate.dialect}
+defaultSchema=${maven.jdbc.schema}
+dbBaseDir=${basedir}
+makeBaseDb=false
+testMarshalling=false


### PR DESCRIPTION
During FDBs process, I noticed 4 failed tests for this repo:
![Screenshot from 2020-07-01 20-59-56](https://user-images.githubusercontent.com/16005046/86281510-f329f080-bbdd-11ea-8e5d-951b73d43555.png)

![Screenshot from 2020-07-01 21-00-28](https://user-images.githubusercontent.com/16005046/86281536-fd4bef00-bbdd-11ea-922c-cc9f4e808fe7.png)

Root cause is related to PR https://github.com/kiegroup/jbpm/pull/1627 which introduces a new property file jbpm-services/jbpm-kie-services/src/test/filtered-resources/datasource.properties, now mandatory for the performed tests.
