### PR TITLE
Mark as provided all external dependencies

### DIFF
--- a/kie-dmn-jpmml/pom.xml
+++ b/kie-dmn-jpmml/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
@@ -77,27 +78,33 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-model</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-feel</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-dmn-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-internal</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- External dependencies -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This change is to simplify reuse of this module both in `kie-dmn` and in `kogito-dmn`
See https://github.com/kiegroup/kogito-runtimes/pull/616#pullrequestreview-444920286