### PR TITLE
[KOGITO-3222] Implement jpmml/trustypmml co-existence

### DIFF
--- a/kie-dmn-jpmml/pom.xml
+++ b/kie-dmn-jpmml/pom.xml
@@ -151,4 +151,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>1.0.6</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/kie-dmn-jpmml/pom.xml
+++ b/kie-dmn-jpmml/pom.xml
@@ -157,7 +157,6 @@
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.0.6</version>
         <executions>
           <execution>
             <id>make-index</id>


### PR DESCRIPTION
This PR depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1451

@danielezonca @tarilabs  @jiripetrlik

See https://issues.redhat.com/browse/KOGITO-3222

This PR add Jandex indexing to kie-dmn-jpmml