### PR TITLE
[8.44.x] Update version to 8.44.0.Final

### DIFF
--- a/kie-dmn-jpmml/pom.xml
+++ b/kie-dmn-jpmml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-jpmml-integration</artifactId>
-    <version>8.44.1-SNAPSHOT</version>
+    <version>8.44.0.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kie-dmn-jpmml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>drools-build-parent</artifactId>
-    <version>8.44.1-SNAPSHOT</version>
+    <version>8.44.0.Final</version>
   </parent>
 
   <artifactId>kie-jpmml-integration</artifactId>


### PR DESCRIPTION
Generated by build jenkins-KIE-drools-8.44.x-release-kie-jpmml-integration-deploy-2: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/drools/job/8.44.x/job/release/job/kie-jpmml-integration-deploy/2/.
Please do not merge, it should be merged automatically.